### PR TITLE
Flip check for location services enabled

### DIFF
--- a/Test App 2/MyViewControllerViewController.m
+++ b/Test App 2/MyViewControllerViewController.m
@@ -57,7 +57,7 @@
     secondArg.returnKeyType = UIReturnKeyDone;
     firstArg.delegate = self;
     secondArg.delegate = self;
-    [NSTimer scheduledTimerWithTimeInterval:0.1
+    [NSTimer scheduledTimerWithTimeInterval:0.2
                                      target:self
                                    selector:@selector(logLocationAuthFromTimer:)
                                    userInfo:nil
@@ -80,7 +80,7 @@
 - (void)logLocationAuth
 {
     CLAuthorizationStatus status = [CLLocationManager authorizationStatus];
-    if (status == kCLAuthorizationStatusAuthorized) {
+    if (status != kCLAuthorizationStatusRestricted && status != kCLAuthorizationStatusDenied) {
         locationStatus.on = YES;
     } else {
         locationStatus.on = NO;
@@ -170,7 +170,7 @@
 
 - (IBAction)accessLocationAlert:(id)sender {
     CLLocationManager *locationManager = [[CLLocationManager alloc] init];
-    
+
     [locationManager startUpdatingLocation];
     [locationManager stopUpdatingLocation];
 }


### PR DESCRIPTION
In iOS 8.x there are different checks for whether location services is on. The negative case, however, is the same. So switch to test the negative case. Fixes apparent flakiness in setting location services wherein the service is on, and then appears to turn off.