### PR TITLE
Add URL Type to test deeplinks

### DIFF
--- a/Test App 2/TestApp-Info.plist
+++ b/Test App 2/TestApp-Info.plist
@@ -20,16 +20,29 @@
 	<string>1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>io.appium.TestApp</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>testapp</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationExitsOnSuspend</key>
 	<true/>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>
 	</array>
-	<key>UIApplicationExitsOnSuspend</key>
-	<true/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
In order to test https://github.com/appium/appium-ios-driver/pull/224 changes, I added `testapp` as a URL Scheme. You can use `xcrun simctl openurl booted testapp://` to open the app.